### PR TITLE
AMoAdRequest_networkSettings

### DIFF
--- a/AMoAdNativeDemo/AMoAdNativeDemo.xcodeproj/project.pbxproj
+++ b/AMoAdNativeDemo/AMoAdNativeDemo.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		E906664E1C8ED53900DD7FAF /* AMoAdRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AMoAdRequest.h; path = AMoAdSdk/AMoAdRequest.h; sourceTree = "<group>"; };
 		E9927BE01C5B776C00BD5174 /* AMoAdNativeDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AMoAdNativeDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E9927BE41C5B776C00BD5174 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		E9927BE61C5B776C00BD5174 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -104,6 +105,7 @@
 				E9927BFB1C5B77ED00BD5174 /* AMoAd.h */,
 				E9927BFC1C5B77ED00BD5174 /* AMoAdLogger.h */,
 				E9927BFD1C5B77ED00BD5174 /* AMoAdNative.h */,
+				E906664E1C8ED53900DD7FAF /* AMoAdRequest.h */,
 				E9927BFE1C5B77ED00BD5174 /* libAMoAd.a */,
 			);
 			name = AMoAdSdk;
@@ -340,6 +342,7 @@
 				E9927BF91C5B776C00BD5174 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/AMoAdNativeDemo/AMoAdNativeDemo/AMoAdSdk/AMoAdNative.h
+++ b/AMoAdNativeDemo/AMoAdNativeDemo/AMoAdSdk/AMoAdNative.h
@@ -60,7 +60,6 @@
 
 /// 開発用
 + (void)setHtmlUrlString:(NSString *)htmlUrlString;
-+ (void)setNetworkTimeoutSeconds:(NSTimeInterval)seconds;
 + (void)loadWithSid:(NSString *)sid tag:(NSString *)tag frame:(CGRect)frame completion:(void (^)(NSString *sid, NSString *tag, AMoAdResult result, NSDictionary *serverInfo))completion option:(NSDictionary *)option;
 - (instancetype)init __attribute__((unavailable("This method is not available.")));
 @end

--- a/AMoAdNativeDemo/AMoAdNativeDemo/AMoAdSdk/AMoAdRequest.h
+++ b/AMoAdNativeDemo/AMoAdNativeDemo/AMoAdSdk/AMoAdRequest.h
@@ -1,0 +1,25 @@
+//
+//  AMoAdRequest.h
+//
+//  Created by AMoAd on 2016/03/07.
+//
+#import <Foundation/Foundation.h>
+
+@interface AMoAdRequest : NSObject
+
+/// ネットワークタイムアウト時間を取得する（デフォルトは30.0秒）
++ (NSTimeInterval)timeoutInterval;
+
+/// ネットワークタイムアウト時間を設定する（デフォルトは30.0秒）
++ (void)setTimeoutInterval:(NSTimeInterval)interval;
+
+/// SSL通信の使用を取得する（デフォルト：NO） ※ YESにしてもATS抑制の設定は必要です
++ (BOOL)isSsl;
+
+/// SSL通信の使用を設定する（デフォルト：NO） ※ YESにしてもATS抑制の設定は必要です
++ (void)setSsl:(BOOL)flg;
+
+/// 使用不可
+- (instancetype)init __attribute__((unavailable("This method is not available.")));
+
+@end

--- a/AMoAdNativeDemo/AMoAdNativeDemo/Info.plist
+++ b/AMoAdNativeDemo/AMoAdNativeDemo/Info.plist
@@ -43,5 +43,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 </dict>
 </plist>

--- a/AMoAdNativeDemo/AMoAdNativeDemo/ViewController.m
+++ b/AMoAdNativeDemo/AMoAdNativeDemo/ViewController.m
@@ -7,8 +7,9 @@
 //
 
 #import "ViewController.h"
-#import "AMoAdNative.h" // [SDK] ネイティブHTML広告
-#import "AMoAdLogger.h" // [SDK] ロガー
+#import "AMoAdNative.h"   // [SDK] ネイティブHTML広告
+#import "AMoAdRequest.h"  // [SDL] ネットワーク設定
+#import "AMoAdLogger.h"   // [SDK] ロガー
 
 @interface ViewController ()
 
@@ -28,6 +29,12 @@ static NSString *const kTag = @"Ad01";
   // [SDK] トレース出力の設定
   [AMoAdLogger sharedLogger].trace = YES;
 
+  // [SDK] タイムアウト時間を設定する
+  [AMoAdRequest setTimeoutInterval:5.0];
+
+  // [SDK] SSL通信の使用を設定する（デフォルト：NO）※ YESにしてもATS抑制の設定は必要です
+//  [AMoAdRequest setSsl:YES];
+  
   // [SDK] 表示位置とサイズを指定する
   CGRect frame = CGRectMake(20, 100, 140, 120);
 

--- a/README.md
+++ b/README.md
@@ -43,10 +43,14 @@ loadメソッドに以下のJSON文字列を渡すことで、広告の枠線を
 
 [AMoAd Native API](AMoAdNativeDemo/AMoAdNativeDemo/AMoAdSdk/AMoAdNative.h)
 
-[AMoAd Logger API](AMoAdNativeDemo/AMoAdNativeDemo/AMoAdSdk/AMoAdLogger.h)
+[AMoAd Request API](AMoAdNativeDemo/AMoAdNativeDemo/AMoAdSdk/AMoAdRequest.h) ... ネットワーク設定
+
+[AMoAd Logger API](AMoAdNativeDemo/AMoAdNativeDemo/AMoAdSdk/AMoAdLogger.h) ... ログ出力設定
 
 ## Project Settings
 
 ### 設定例
+
+[ATS (App Transport Security) を抑制する](https://github.com/amoad/amoad-ios-sdk/blob/master/Documents/Install/Install.asciidoc#ats-app-transport-security-を抑制する)
 
 <img width="640" src="docs/res/ScreenShot04.png">


### PR DESCRIPTION
1. ネットワークタイムアウトを設定できるようになりました。
2. SSLを使用するかどうか設定できるようになりました。
3. SSLがデフォルトでOFFになりました。

※ SSLをONにしていても、広告主側計測ツールの都合で、ATS抑制の設定をする必要があります。
